### PR TITLE
Fix conflict with different version number

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Parallax-ImageScroll",
-  "version": "0.1",
+  "version": "0.1.0",
   "authors": [
     "Peder Andreas Nielsen <peder1976@gmail.com>"
   ],


### PR DESCRIPTION
Hello, I use your script in one of my current project.
I had little problem today morning with bower, cause in bower.json is different version number than in tags on github.com in Parallax-ImageScroll repository.

Now if I will install it with bower, I get

```
bower checkout      Parallax-ImageScroll#0.1.0
bower error         Invalid Version: 0.1
```

If you can merge this pull request, it would be awesome and bower will be happy to ;)
