### PR TITLE
Add Browserify/CommonJS support

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -40,7 +40,7 @@
     </section>
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-<script src="../jquery.imageScroll.min.js"></script>
+<script src="../jquery.imageScroll.js"></script>
     <script>
         $('.img-holder').imageScroll({
 //            image: null,

--- a/jquery.imageScroll.js
+++ b/jquery.imageScroll.js
@@ -11,7 +11,13 @@
 ;
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
+        // AMD
         define(['jquery'], factory);
+    } else if (typeof module === 'object' && typeof module.exports === 'object') {
+        // CommonJS
+        module.exports = factory(
+            require('jquery')
+        );
     } else {
         factory(root.jQuery);
     }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "parallax-imagescroll",
     "version": "0.2.1",
     "title": "Parallax ImageScroll",
+    "main": "./jquery.imageScroll.js",
     "author": {
         "name": "Peder Andreas Nielsen",
         "email": "peder1976@gmail.com"


### PR DESCRIPTION
I'm currently pulling in your plugin via npm, and running it in a browserify/gulp stack. To effectively `require` it in, I needed to specify a `main` path in package.json, and add a commonjs/browserify check. Hoping you can merge it in... love using your plugin. 