### PR TITLE
add role=presentation to generated img tag

### DIFF
--- a/jquery.imageScroll.js
+++ b/jquery.imageScroll.js
@@ -216,7 +216,8 @@
         init: function () {
             if (this.image) {
                 this.$scrollingElement = $('<img/>', {
-                    src: this.image
+                    src: this.image,
+                    role: 'presentation'
                 }).addClass(this.settings.imgClass);
             } else {
                 throw new Error('You need to provide either a data-img attr or an image option');


### PR DESCRIPTION
The generated `<img/>` was causing a11y to fail due to a lack of either an `alt` or `role="presentation` attribute.  This commit adds the `role="presentation` to the image and allows a11y to pass.
